### PR TITLE
Replace chumsky by naive parsing in `ultisnips-in`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,6 +368,7 @@ dependencies = [
  "json5",
  "serde",
  "thiserror",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -424,6 +425,12 @@ name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,17 +3,6 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
-dependencies = [
- "cfg-if",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,16 +85,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "chumsky"
-version = "1.0.0-alpha.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3172a80699de358070dd99f80ea8badc6cdf8ac2417cb5a96e6d81bf5fe06d"
-dependencies = [
- "hashbrown",
- "stacker",
-]
-
-[[package]]
 name = "clap"
 version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +148,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
 name = "errno"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,15 +185,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
-dependencies = [
- "ahash",
-]
-
-[[package]]
 name = "hermit-abi"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +211,15 @@ dependencies = [
  "io-lifetimes",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -320,15 +305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "psm"
-version = "0.1.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5787f7cda34e3033a72192c018bc5883100330f362ef279a8cbccfce8bb4e874"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -387,24 +363,11 @@ name = "snippets-everywhere"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "chumsky",
  "clap",
+ "itertools",
  "json5",
  "serde",
  "thiserror",
-]
-
-[[package]]
-name = "stacker"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c886bd4480155fd3ef527d45e9ac8dd7118a898a46530b7b94c3e21866259fce"
-dependencies = [
- "cc",
- "cfg-if",
- "libc",
- "psm",
- "winapi",
 ]
 
 [[package]]
@@ -473,28 +436,6 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
-
-[[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow       = "1.0"
 clap         = { version = "4.3", features = ["string"] }
-itertools    = "0.11.0"
+itertools    = "0.11"
 serde        = { version = "1.0", features = ["derive"] }
 unicode-segmentation = "1.10"
 json5        = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 anyhow       = "1.0"
 clap         = { version = "4.3", features = ["string"] }
-chumsky      = "1.0.0-alpha.4"
+itertools    = "0.11.0"
 serde        = { version = "1.0", features = ["derive"] }
 json5        = "0.4"
 thiserror    = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,5 +9,6 @@ anyhow       = "1.0"
 clap         = { version = "4.3", features = ["string"] }
 itertools    = "0.11.0"
 serde        = { version = "1.0", features = ["derive"] }
+unicode-segmentation = "1.10"
 json5        = "0.4"
 thiserror    = "1.0"

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python -c 'import json, pathlib; print(json.loads(pathlib.Path("$YOUR_VAULT_PATH
 ## Caveats
 
 - The [UltiSnips] snippet _parser_ as triggered through using `--ultisnips-in` tries to replicate the parsing of UltiSnips itself as closely as reasonably possible. This also includes the same surprising behaviors: `"wow"` as trigger is parsed as `"wow"`, unquoted, but `"wow more"` is parsed as `wow more`, quoted.
-- Also, parsing and following `priority` and `extends` directives in the [UltiSnips] parser isn't implemented. Would be easy to add, though.
+- Parsing and following `extends` directives in the [UltiSnips] parser isn't implemented. Would be easy to add, though.
 - Comments are not preserved, and not even parsed by the input backends, just skipped.
 - The [OLS] output is very condensed, and not pretty printed. If you want or need pretty printing, you can throw it through `python -m json.tool`.
 

--- a/README.md
+++ b/README.md
@@ -33,22 +33,7 @@ python -c 'import json, pathlib; print(json.loads(pathlib.Path("$YOUR_VAULT_PATH
 
 ## Caveats
 
-- The [UltiSnips] snippet _parser_ as triggered through using `--ultisnips-in` is slightly buggy and a bit more lenient than what [UltiSnips] itself would accept. The buginess mostly stems from the fact that [UltiSnips] allows any character as quote, but internally actually performs RTL parsing, which is hard to emulate using a PEG
-
-  <details>
-  Let's say you have this wonderfully slightly useless snippet:
-
-  ```snippets
-  snippet wall "Yeah." Aw
-  door
-  endsnippet
-  ```
-
-  What would you expect this to be parsed as? Well, [UltiSnips] parses this as `wall` as trigger, `Yeah.` as description and `Aw` as options, but the parser in this repo currently parses this as `all "Yeah." A` as trigger, with no description and option, since `w` is a valid quote character. And this is difficult to solve correctly. [UltiSnips] just takes the last two words it sees, figures out if they are description and option, and searches for the beginning of the description appropiately, then ignoring them when finally parsing the trigger.
-
-  But in a PEG, this is... weird. I believe the only way to meaningfully emulate this is by checking at each character in the trigger if the following text would make sense as description and options, too, but that's not done at the moment, since I would want a clean solution.
-  </details>
-
+- The [UltiSnips] snippet _parser_ as triggered through using `--ultisnips-in` tries to replicate the parsing of UltiSnips itself as closely as reasonably possible. This also includes the same surprising behaviors: `"wow"` as trigger is parsed as `"wow"`, unquoted, but `"wow more"` is parsed as `wow more`, quoted.
 - Also, parsing and following `priority` and `extends` directives in the [UltiSnips] parser isn't implemented. Would be easy to add, though.
 - Comments are not preserved, and not even parsed by the input backends, just skipped.
 - The [OLS] output is very condensed, and not pretty printed. If you want or need pretty printing, you can throw it through `python -m json.tool`.

--- a/samples/one-quoted.json5
+++ b/samples/one-quoted.json5
@@ -1,0 +1,1 @@
+[{"trigger":"1 2","replacement":"expanded!"}]

--- a/samples/one-quoted.snippets
+++ b/samples/one-quoted.snippets
@@ -1,4 +1,4 @@
-# this is actually bb, the a is interpreted as quote character
-snippet a12a
+# this is actually 1 2, the a is interpreted as quote character
+snippet a1 2a
 expanded!
 endsnippet

--- a/samples/one-unquoted.json5
+++ b/samples/one-unquoted.json5
@@ -1,0 +1,1 @@
+[{"trigger":"a1a2","replacement":"expanded!"},{"trigger":"a12a","replacement":"another one! yeah, still unquoted since ultisnips checks for multi-word first"}]

--- a/samples/one-unquoted.snippets
+++ b/samples/one-unquoted.snippets
@@ -1,8 +1,11 @@
-# hi please ignore me thank you
 # snippet owo
 # actually not a snippet
 # endsnippet
 
 snippet a1a2
 expanded!
+endsnippet
+
+snippet a12a
+another one! yeah, still unquoted since ultisnips checks for multi-word first
 endsnippet

--- a/samples/technically-trigger-but-not.json5
+++ b/samples/technically-trigger-but-not.json5
@@ -1,0 +1,1 @@
+[{"trigger":"all \"Yeah.\" A","replacement":"door"},{"trigger":"door","replacement":"wall","options":"Aw","description":"Yeah."}]

--- a/samples/technically-trigger-but-not.json5
+++ b/samples/technically-trigger-but-not.json5
@@ -1,1 +1,1 @@
-[{"trigger":"all \"Yeah.\" A","replacement":"door"},{"trigger":"door","replacement":"wall","options":"Aw","description":"Yeah."}]
+[{"trigger":"wall","replacement":"door","options":"Aw","description":"Yeah."},{"trigger":"door","replacement":"wall","options":"Aw","description":"Yeah."}]

--- a/samples/technically-trigger-but-not.snippets
+++ b/samples/technically-trigger-but-not.snippets
@@ -1,0 +1,6 @@
+snippet wall "Yeah." Aw
+door
+endsnippet
+snippet door "Yeah." Aw
+wall
+endsnippet

--- a/samples/technically-trigger-but-not.snippets
+++ b/samples/technically-trigger-but-not.snippets
@@ -1,6 +1,7 @@
 snippet wall "Yeah." Aw
 door
 endsnippet
+
 snippet door "Yeah." Aw
 wall
 endsnippet

--- a/src/backends/ultisnips/de.rs
+++ b/src/backends/ultisnips/de.rs
@@ -3,15 +3,15 @@ use std::num::ParseIntError;
 use anyhow::Result;
 use itertools::Itertools;
 use thiserror::Error;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::{Snippet, SnippetFile};
 
 pub fn deserialize(input: &str) -> Result<SnippetFile> {
-    // TODO: `priority n` commands
     // TODO: `extends` command, maybe not even necessary
 
     let mut snippets = Vec::new();
-    let mut current_priority = 0;
+    let mut current_priority = None;
 
     // external since it's also used inside the loop itself
     let mut lines_iter = input.lines().peekable();
@@ -38,7 +38,7 @@ pub fn deserialize(input: &str) -> Result<SnippetFile> {
                 let snippet = parse_snippet(&relevant_lines, current_priority)?;
                 snippets.push(snippet);
             }
-            Some("priority") => current_priority = parse_priority(line)?,
+            Some("priority") => current_priority = Some(parse_priority(line)?),
             Some(unknown) => {
                 return Err(ParseError::UnknownDirective {
                     directive: unknown.to_string(),
@@ -55,14 +55,73 @@ pub fn deserialize(input: &str) -> Result<SnippetFile> {
 enum ParseError {
     #[error("unknown directive: `{directive}`")]
     UnknownDirective { directive: String },
-    #[error("no number after `priority` directive")]
+    #[error("found no trigger after `snippet`")]
+    MissingSnippetTrigger,
+    #[error("found no number after `priority` directive")]
     MissingPriorityNumber,
     #[error("tried to parse number in `{subject}` but failed: {err}")]
     ParsePriorityNumber { subject: String, err: ParseIntError },
 }
 
-fn parse_snippet(lines: &[String], current_priority: i64) -> Result<Snippet> {
-    todo!()
+fn parse_snippet(lines: &[String], priority: Option<i64>) -> Result<Snippet, ParseError> {
+    // basically snippet/source/file/ulti_snips.py in the UltiSnips repo ported
+    // first parsing the signature `snippet trigger [ description [ options ] ]`
+    // remember: description and options are optional, trigger may be quoted weirdly
+    let first_line = lines.get(0).expect("caller passing lines to parse");
+    let mut parts: Vec<_> = first_line.split_whitespace().collect();
+
+    let trigger;
+    let mut description = None;
+    let mut options = None;
+
+    match parts.len() {
+        0 => panic!("expected caller to not pass empty lines"),
+        1 => return Err(ParseError::MissingSnippetTrigger),
+        2 => {
+            // `snippet trigger` (being unquoted)
+            trigger = parts.last().unwrap().to_string();
+        }
+        _ => {
+            // possibly description,
+            // possibly description with option,
+            // possibly just quoted trigger
+
+            // are options there?
+            if !parts.last().unwrap().ends_with('"') && parts[parts.len() - 2].ends_with('"') {
+                options = parts.pop().map(|opts| opts.to_string());
+            }
+
+            // is a description there?
+            if parts.last().unwrap().ends_with('"') {
+                let _accumulated_desc = String::new();
+                todo!()
+            }
+
+            // then everything remaining will be the trigger
+            if parts.len() >= 2 {
+                // quoted
+                // actually according to :h UltiSnips-snippet-options, both single-word and
+                // multi-word triggers can be quoted, but the code only implements the latter
+                // (and checks for regex, too). so that's emulated here
+                let quoted = parts[1..].iter().format(" ").to_string();
+                let graphemes: Vec<_> = quoted.graphemes(true).collect();
+                trigger = graphemes[1..graphemes.len() - 1].iter().copied().collect();
+            } else {
+                // unquoted
+                trigger = parts[1].to_string();
+            }
+        }
+    }
+
+    let replacement = lines[1..lines.len() - 1].iter().format("\n").to_string();
+
+    Ok(Snippet {
+        trigger,
+        replacement,
+        options,
+        description,
+        priority,
+    })
 }
 
 fn parse_priority(line: &str) -> Result<i64, ParseError> {

--- a/src/backends/ultisnips/de.rs
+++ b/src/backends/ultisnips/de.rs
@@ -58,7 +58,7 @@ fn parser<'a>() -> impl Parser<'a, &'a str, SnippetFile, extra::Err<Simple<'a, c
         .collect::<String>()
         .padded_by(just('"'));
 
-    let options = just('A').map(|ch| ch.to_string());
+    let options = one_of("biwrtsmeA").repeated().collect::<String>();
 
     let content = any()
         .and_is(just('\n').then(text::keyword("endsnippet")).not())

--- a/src/backends/ultisnips/de.rs
+++ b/src/backends/ultisnips/de.rs
@@ -1,106 +1,59 @@
-use anyhow::anyhow;
-use chumsky::prelude::*;
+use anyhow::Result;
+use itertools::Itertools;
 use thiserror::Error;
 
 use crate::{Snippet, SnippetFile};
 
-pub fn deserialize(input: &str) -> anyhow::Result<SnippetFile> {
-    parser()
-        .parse(input)
-        .into_result()
-        // directly converting the error to a string is... crude, but it works
-        // can't directly return ParseError anyway since it contains a Simple with a lifetime
-        // in a more serious project probably a custom/another error type would be better
-        .map_err(|err| anyhow!(ParseError(err).to_string()))
+pub fn deserialize(input: &str) -> Result<SnippetFile> {
+    // TODO: `priority n` commands
+    // TODO: `extends` command, maybe not even necessary
+
+    let mut snippets = Vec::new();
+    let mut current_priority = 0;
+
+    // external since it's also used inside the loop itself
+    let mut lines_iter = input.lines().peekable();
+
+    while let Some(line) = lines_iter.next() {
+        let line = line.trim();
+
+        if line.starts_with('#') {
+            continue;
+        }
+
+        match line.split_whitespace().next() {
+            None => continue, // will have just been whitespace or completely empty
+            Some("snippet") => {
+                let mut relevant_lines = vec![line.to_string()];
+
+                relevant_lines.extend(
+                    lines_iter
+                        .peeking_take_while(|line| line.trim() != "endsnippet")
+                        .map(|line| line.to_string()),
+                );
+                relevant_lines.push(lines_iter.next().unwrap().to_string());
+
+                let snippet = parse_snippet(&relevant_lines, &mut current_priority)?;
+                snippets.push(snippet);
+            }
+            Some(unknown) => {
+                return Err(ParseError::UnknownDirective {
+                    directive: unknown.to_string(),
+                }.into())
+            }
+        }
+    }
+
+    Ok(SnippetFile { snippets })
 }
 
 #[derive(Debug, Error)]
-#[error(
-    "error(s) parsing UltiSnips snippet file:\n{}",
-    .0.iter().flat_map(|err| {
-        err
-            .to_string()
-            .chars()
-            .collect::<Vec<_>>()
-            .into_iter()
-    }).collect::<String>()
-)]
-struct ParseError<'a>(Vec<Simple<'a, char>>);
+enum ParseError {
+    #[error("unknown directive: `{directive}`")]
+    UnknownDirective { directive: String },
+}
 
-fn parser<'a>() -> impl Parser<'a, &'a str, SnippetFile, extra::Err<Simple<'a, char>>> {
-    // TODO: `priority n` commands
-    // TODO: `extends` command, maybe not even necessary
-    let quote_end = just('X') // placeholder char -- doesn't matter, will be immediately replaced
-        .configure(|cfg, first_ch| cfg.seq(*first_ch));
-    let quoted_trigger = any().then_with_ctx(
-        any()
-            // the whitespace check is necessary to find out
-            // if that's really been at the end of the word and not in-between
-            // (yeah, that's actually not what UltiSnips does, but UltiSnips does RTL
-            // parsing anyway, we're merely trying to emulate it)
-            .and_is(quote_end.then(text::whitespace().at_least(1)).not())
-            .and_is(text::newline().not())
-            .repeated()
-            .collect::<String>()
-            .then_ignore(quote_end),
-    );
-
-    let unquoted_trigger = any()
-        .and_is(text::whitespace().at_least(1).not())
-        .repeated()
-        .collect::<String>();
-
-    // :h UltiSnips-basic-syntax doesn't give any more explanation on escaping or the like, apart
-    // from the description being always quoted. so we'll do exactly that
-    let description = any()
-        .and_is(just('"').not())
-        .repeated()
-        .collect::<String>()
-        .padded_by(just('"'));
-
-    let options = one_of("biwrtsmeA").repeated().collect::<String>();
-
-    let content = any()
-        .and_is(just('\n').then(text::keyword("endsnippet")).not())
-        .repeated()
-        .collect::<String>()
-        .then_ignore(just('\n').then(text::keyword("endsnippet")));
-
-    let space = one_of(" \t").repeated().at_least(1);
-    let signature = text::keyword("snippet")
-        .then(space)
-        .ignore_then(quoted_trigger.or(unquoted_trigger))
-        .then(
-            space
-                .ignore_then(description.then(space.ignore_then(options).or_not()))
-                .or_not(),
-        );
-
-    let snippet = signature.then_ignore(just('\n')).then(content).map(
-        |((trigger, maybe_more), replacement)| {
-            let (description, options) = match maybe_more {
-                Some((desc, None)) => (Some(desc), None),
-                Some((desc, Some(opts))) => (Some(desc), Some(opts)),
-                _ => (None, None),
-            };
-
-            Snippet {
-                trigger,
-                replacement,
-                description,
-                options,
-                priority: None,
-            }
-        },
-    );
-
-    let comment = just('#').then(any().and_is(just('\n').not()).repeated());
-
-    let everything_ignored = choice((text::whitespace().at_least(1), comment.ignored())).repeated();
-
-    snippet
-        .padded_by(everything_ignored)
-        .repeated()
-        .collect::<Vec<_>>()
-        .map(|snippets| SnippetFile { snippets })
+fn parse_snippet(lines: &[String], current_priority: &mut i64) -> Result<Snippet> {
+    dbg!(lines);
+    todo!()
 }

--- a/src/backends/ultisnips/mod.rs
+++ b/src/backends/ultisnips/mod.rs
@@ -4,6 +4,8 @@ mod tests;
 mod de;
 mod ser;
 
+use anyhow::Context;
+
 use crate::SnippetFile;
 
 use super::Backend;
@@ -20,7 +22,7 @@ impl Backend for UltiSnips {
     }
 
     fn deserialize(&self, input: &str) -> anyhow::Result<SnippetFile> {
-        de::deserialize(input)
+        de::deserialize(input).context("error while parsing UltiSnips snippets")
     }
 
     fn serialize(&self, snippets: &SnippetFile) -> anyhow::Result<String> {

--- a/src/backends/ultisnips/tests.rs
+++ b/src/backends/ultisnips/tests.rs
@@ -3,18 +3,10 @@ use crate::Snippet;
 use super::*;
 
 #[test]
-fn deserialize_multiple() {
+fn deserialize_unquoted() {
     let input = r#"
-snippet written "" Aw
-replaced
-endsnippet
-
-snippet a "" A
-b
-endsnippet
-
 snippet written
-conflict
+wow
 endsnippet
     "#;
 
@@ -22,27 +14,78 @@ endsnippet
     assert_eq!(
         ir,
         SnippetFile {
-            snippets: vec![
-                Snippet {
-                    trigger: "written".to_string(),
-                    replacement: "replaced".to_string(),
-                    description: Some(String::new()),
-                    options: Some("Aw".to_string()),
-                    ..Default::default()
-                },
-                Snippet {
-                    trigger: "a".to_string(),
-                    replacement: "b".to_string(),
-                    description: Some(String::new()),
-                    options: Some("A".to_string()),
-                    ..Default::default()
-                },
-                Snippet {
-                    trigger: "written".to_string(),
-                    replacement: "conflict".to_string(),
-                    ..Default::default()
-                },
-            ]
+            snippets: vec![Snippet {
+                trigger: "written".to_string(),
+                replacement: "wow".to_string(),
+                ..Default::default()
+            }]
         }
     );
+}
+
+#[test]
+fn deserialize_quoted() {
+    let input = r#"
+snippet woah this is a long trigger wow
+truly
+endsnippet
+    "#;
+
+    let ir = UltiSnips.deserialize(input).unwrap();
+    assert_eq!(
+        ir,
+        SnippetFile {
+            snippets: vec![Snippet {
+                // yes, this is intended
+                trigger: "oah this is a long trigger wo".to_string(),
+                replacement: "truly".to_string(),
+                ..Default::default()
+            }]
+        }
+    );
+}
+
+#[test]
+fn deserialize_desc_and_opts() {
+    let input = r#"
+snippet written "" Aw
+replaced
+endsnippet
+    "#;
+
+    let ir = UltiSnips.deserialize(input).unwrap();
+    assert_eq!(
+        ir,
+        SnippetFile {
+            snippets: vec![Snippet {
+                trigger: "written".to_string(),
+                replacement: "replaced".to_string(),
+                description: Some(String::new()),
+                options: Some("Aw".to_string()),
+                ..Default::default()
+            }],
+        },
+    );
+}
+
+#[test]
+fn deserialize_very_concise_with_desc() {
+    let input = r#"
+snippet a ""
+b
+endsnippet
+    "#;
+
+    let ir = UltiSnips.deserialize(input).unwrap();
+    assert_eq!(
+        ir,
+        SnippetFile {
+            snippets: vec![Snippet {
+                trigger: "a".to_string(),
+                replacement: "b".to_string(),
+                description: Some(String::new()),
+                ..Default::default()
+            }],
+        },
+    )
 }

--- a/src/backends/ultisnips/tests.rs
+++ b/src/backends/ultisnips/tests.rs
@@ -48,7 +48,7 @@ endsnippet
 #[test]
 fn deserialize_desc_and_opts() {
     let input = r#"
-snippet written "" Aw
+snippet written "long description" Aw
 replaced
 endsnippet
     "#;
@@ -60,7 +60,7 @@ endsnippet
             snippets: vec![Snippet {
                 trigger: "written".to_string(),
                 replacement: "replaced".to_string(),
-                description: Some(String::new()),
+                description: Some("long description".to_string()),
                 options: Some("Aw".to_string()),
                 ..Default::default()
             }],


### PR DESCRIPTION
Should fix most of the parser bugs. The UltiSnips snippet format is hopelessly underspecified and unclear on subtle changes, however, this parser tries to replicate the functionality _in_ UltiSnips as closely as possible — which also means the same surprises with quotings, RTL parsing and what not.